### PR TITLE
h関数を直接呼び出してUIをレンダリングしていた部分を、より小さく再利用可能なコンポーネント関数にリファクタリングしました。

### DIFF
--- a/src/ui/Results.js
+++ b/src/ui/Results.js
@@ -2,23 +2,66 @@ import { h } from '../vdom.js';
 import { Col } from '../components/uiPrimitives.js';
 import { CollapsibleCard } from '../components/CollapsibleCard.js';
 
-function renderResultCard(result) {
+// --- Child Components ---
+
+/**
+ * Renders a small badge, typically overlaid on a card.
+ * @param {object} props
+ * @param {string} props.text - The text to display in the badge.
+ * @param {string} props.position - CSS position classes (e.g., 'top-0 start-0').
+ * @param {string} props.color - Bootstrap background color class (e.g., 'bg-warning').
+ * @returns {object} A VDOM node.
+ */
+const Badge = ({ text, position, color }) => h('span', {
+    class: `badge ${color} text-dark position-absolute ${position} m-1`
+}, [text]);
+
+/**
+ * Renders a single gacha result card.
+ * @param {object} props
+ * @param {object} props.result - The result object from the simulation.
+ * @returns {object} A VDOM node.
+ */
+const ResultCard = ({ result }) => {
     const { id, rarity, isPu, guaranteed } = result;
     const cardClasses = `card result-card text-center h-100 ${rarity.toLowerCase()}${isPu ? ' pickup' : ''}`;
-    const badges = [];
-
-    if (isPu) badges.push(h('span', { class: 'badge bg-warning text-dark position-absolute top-0 start-0 m-1' }, ['PU']));
-    if (guaranteed) badges.push(h('span', { class: 'badge bg-info text-dark position-absolute top-0 end-0 m-1' }, ['天井']));
 
     return h('div', { key: id, class: 'col result-card-wrapper' }, [
         h('div', { class: cardClasses }, [
-            ...badges,
+            isPu && Badge({ text: 'PU', position: 'top-0 start-0', color: 'bg-warning' }),
+            guaranteed && Badge({ text: '天井', position: 'top-0 end-0', color: 'bg-info' }),
             h('div', { class: 'card-body p-2 d-flex flex-column justify-content-center' }, [
                 h('h5', { class: 'card-title mb-0' }, [rarity])
             ])
         ])
     ]);
-}
+};
+
+/**
+ * Renders a batch of gacha results.
+ * @param {object} props
+ * @param {Array} props.resultBatch - An array of result objects.
+ * @param {number} props.index - The index of this batch in the main results array.
+ * @param {number} props.totalPulls - The total number of batches.
+ * @returns {object} A VDOM node.
+ */
+const ResultBatch = ({ resultBatch, index, totalPulls }) => {
+    const isSinglePull = resultBatch.length === 1;
+    const pullType = isSinglePull ? '単発' : `${resultBatch.length}連`;
+    const pullNumber = totalPulls - index;
+    const isLatest = index === 0;
+    const title = `${pullType}ガチャ (${pullNumber}回目)${isLatest ? ' (最新)' : ''}`;
+
+    return h('div', { class: 'result-batch mb-4' }, [
+        h('h4', { class: 'fs-6 fw-bold text-muted border-bottom pb-2 mb-3' }, [title]),
+        h('div', { class: 'row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 g-3' },
+            resultBatch.map(result => ResultCard({ result }))
+        )
+    ]);
+};
+
+
+// --- Main Exported Component ---
 
 /**
  * Renders the results display panel.
@@ -26,28 +69,13 @@ function renderResultCard(result) {
  * @returns {object} A VDOM node.
  */
 export function Results({ state }) {
-    // The results container is now a Card to match the Status panel
+    const totalPulls = state.results.length;
+
     return Col({ size: 8 }, [
         CollapsibleCard({ id: 'results', title: '結果' },
-            // We map over the reversed array of result *batches*
-            [...state.results].reverse().map((resultBatch, index) => {
-                const isSinglePull = resultBatch.length === 1;
-                const pullType = isSinglePull ? '単発' : `${resultBatch.length}連`;
-                const totalPulls = state.results.length;
-                const pullNumber = totalPulls - index;
-                const isLatest = index === 0;
-                const title = `${pullType}ガチャ (${pullNumber}回目)${isLatest ? ' (最新)' : ''}`;
-
-                // Each batch is rendered in its own container
-                return h('div', { class: 'result-batch mb-4' }, [
-                    h('h4', { class: 'fs-6 fw-bold text-muted border-bottom pb-2 mb-3' }, [title]),
-                    h('div', {
-                        class: 'row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 g-3'
-                    },
-                        resultBatch.map(renderResultCard)
-                    )
-                ]);
-            })
+            [...state.results]
+                .reverse()
+                .map((resultBatch, index) => ResultBatch({ resultBatch, index, totalPulls }))
         )
     ]);
 }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -2,6 +2,14 @@ import { h } from './vdom.js';
 import { Controls } from './Controls.js';
 import { Results } from './Results.js';
 
+const AppHeader = () => h('header', { class: 'pb-3 mb-4 border-bottom' }, [
+    h('h1', { class: 'fs-4' }, ['ガチャシミュレーター'])
+]);
+
+const AppFooter = () => h('footer', { class: 'pt-3 mt-4 text-muted border-top' }, [
+    h('p', { class: 'small' }, ['このシミュレーターは、公開されている確率に基づいていますが、あくまでシミュレーションであり、実際の結果を保証するものではありません。また、確率の正確性についても責任を負いません。'])
+]);
+
 /**
  * Renders the entire application UI as a VDOM tree.
  * @param {object} state The current application state.
@@ -16,17 +24,13 @@ export function renderApp(state, actions, allGames) {
     }
 
     return h('div', { class: 'container py-4' }, [
-        h('header', { class: 'pb-3 mb-4 border-bottom' }, [
-            h('h1', { class: 'fs-4' }, ['ガチャシミュレーター'])
-        ]),
+        AppHeader(),
         h('main', {}, [
             h('div', { class: 'row' }, [
                 Controls({ state, actions, allGames }),
                 Results({ state }),
             ])
         ]),
-        h('footer', { class: 'pt-3 mt-4 text-muted border-top' }, [
-            h('p', { class: 'small' }, ['このシミュレーターは、公開されている確率に基づいていますが、あくまでシミュレーションであり、実際の結果を保証するものではありません。また、確率の正確性についても責任を負いません。'])
-        ])
+        AppFooter()
     ]);
 }


### PR DESCRIPTION
- `src/ui/Results.js` では `ResultCard`, `ResultBatch`, `Badge` コンポーネントを導入。
- `src/ui/ui.js` では `AppHeader`, `AppFooter` コンポーネントを導入。

これにより、コードの可読性、メンテナンス性、再利用性が向上します。