### PR TITLE
Fix: Hide exchange points on initial custom settings load

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -62,8 +62,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const customSettings = {
             customSsrRate: state.customSsrRate || 3,
             customSrRate: state.customSrRate || 15,
-            customPityType: state.customPityType || 'exchange',
-            customPityCount: state.customPityCount || 200,
+            customPityType: state.customPityType || 'none',
+            customPityCount: state.customPityCount || 0,
             customPuRate: state.customPuRate || 50,
         };
 


### PR DESCRIPTION
The exchange points were being displayed on the status card by default when the application first loaded with the custom game type. This was because the `customPityType` was defaulting to 'exchange'.

This commit changes the default `customPityType` to 'none' and the default `customPityCount` to 0. This ensures that the exchange points and other pity system information are only displayed after the user has explicitly configured a pity system in the custom settings.