### PR TITLE
Fix: Reset pity counter after drawing an SSR

### DIFF
--- a/src/games/common.js
+++ b/src/games/common.js
@@ -84,6 +84,9 @@ export function unifiedDraw(state, config) {
             isPu = true; // Default to PU if no system is defined
         }
 
+        // SSR is obtained, so reset pity.
+        state.pityCount = 0;
+
         return { rarity: 'SSR', isPu, guaranteed: isHardPity };
 
     } else if (rand < currentSsrRate + config.srRate) {


### PR DESCRIPTION
The pity counter was not being reset to 0 after an SSR was drawn, causing tests to fail. This change adds the line to reset the pity counter, ensuring the gacha simulation logic is correct.